### PR TITLE
downtime announcement for June 18, 2026

### DIFF
--- a/docs/assets/announcement.json
+++ b/docs/assets/announcement.json
@@ -1,6 +1,6 @@
 {
     "type": "ALERT",
-    "message": "⚠️ Scheduled Downtime: All Yen servers will be offline <b>March 26–27, 2026 </b> (through end of day) as we install new GPU and CPU compute nodes to expand compute capacity ⚠️.",
+    "message": "⚠️ Scheduled Downtime: <b>June 18, 2026</b>. All Yen servers will be offline for the day ⚠️.",
     "examples": [
         {
             "type": "ERROR",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,7 +127,7 @@ extra_css:
   - stylesheets/custom.css
 
 extra_javascript:
-#  - js/announcement-banner.js
+  - js/announcement-banner.js
   - js/footer.js
 
 watch:


### PR DESCRIPTION
## Summary
- Updates `docs/assets/announcement.json` with a June 18, 2026 scheduled downtime message
- Re-enables `js/announcement-banner.js` in `mkdocs.yml` to display the banner

## Test plan
- [ ] Verify banner appears on rcpedia-dev.stanford.edu
- [ ] Confirm message reads correctly for June 18 downtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)