### PR TITLE
Remove downtime announcement banner

### DIFF
--- a/docs/assets/announcement.json
+++ b/docs/assets/announcement.json
@@ -1,6 +1,6 @@
 {
-    "type": "ALERT",
-    "message": "⚠️ Scheduled Downtime: <b>June 18, 2026</b>. All Yen servers will be offline for the day ⚠️.",
+    "type": "",
+    "message": "",
     "examples": [
         {
             "type": "ERROR",
@@ -24,4 +24,3 @@
         }
     ]
 }
-

--- a/docs/js/announcement-banner.js
+++ b/docs/js/announcement-banner.js
@@ -184,6 +184,13 @@ document.addEventListener("DOMContentLoaded", function () {
             banner.remove();
         }
     }
+
+    function removeAnnouncementContainer() {
+        const bannerContainer = document.querySelector(".announcement-banner-container");
+        if (bannerContainer) {
+            bannerContainer.remove();
+        }
+    }
     
     // ============== READ JSON AND DECIDE WHETHER TO SHOW BANNER ====================
     fetch('/assets/announcement.json')
@@ -193,6 +200,7 @@ document.addEventListener("DOMContentLoaded", function () {
     
             if (!message || message.trim() === "" || !type) {
                 console.warn("⚠️ No current announcement.");
+                removeAnnouncementContainer();
                 return;
             }
     
@@ -217,9 +225,11 @@ document.addEventListener("DOMContentLoaded", function () {
                 console.log("Announcement is unchanged or dismissed");
             }
         })
-        .catch(error => console.error("Failed to load announcement.json:", error)); 
+        .catch(error => {
+            removeAnnouncementContainer();
+            console.error("Failed to load announcement.json:", error);
+        }); 
 
 });
-
 
 


### PR DESCRIPTION
Summary:
- Clear the active downtime announcement from announcement.json.
- Remove the empty announcement wrapper when no announcement is configured.

Checks:
- python3 -m json.tool docs/assets/announcement.json
- node --check docs/js/announcement-banner.js
- python3 -m mkdocs build --strict (fails locally: No module named mkdocs)