### PR TITLE
Update long partition CPU limit

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -88,7 +88,7 @@ jobs:
           path: site/
 
   deploy:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 20
 
@@ -106,15 +106,12 @@ jobs:
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.MY_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
-          printf '%s\n' "${{ secrets.MY_SSH_KEY }}" | base64 --decode > ~/.ssh/id_rsa || \
-            printf '%s\n' "${{ secrets.MY_SSH_KEY }}" | base64 -D > ~/.ssh/id_rsa
+          echo "${{ secrets.MY_SSH_KEY }}" | base64 --decode > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
 
       - name: DNS debug
         run: |
-          if command -v getent >/dev/null 2>&1; then
-            getent hosts "$SSH_HOST" || true
-          fi
+          getent hosts "$SSH_HOST" || true
           dig +short "$SSH_HOST" || true
 
       - name: Show runner public IP
@@ -123,7 +120,7 @@ jobs:
 
       - name: Verify SSH connection
         run: |
-          ssh -i ~/.ssh/id_rsa -p "$SSH_PORT" \
+          timeout 45s ssh -i ~/.ssh/id_rsa -p "$SSH_PORT" \
             -o BatchMode=yes \
             -o ConnectTimeout=30 \
             -o ServerAliveInterval=10 \
@@ -146,7 +143,7 @@ jobs:
           for attempt in $(seq 1 "$max_attempts"); do
             echo "Deploy attempt $attempt/$max_attempts..."
       
-            if rsync -e "ssh -i ~/.ssh/id_rsa -p $SSH_PORT -o BatchMode=yes -o ConnectTimeout=60 -o ServerAliveInterval=10 -o ServerAliveCountMax=3" \
+            if timeout 300s rsync --timeout=60 -e "ssh -i ~/.ssh/id_rsa -p $SSH_PORT -o BatchMode=yes -o ConnectTimeout=60 -o ServerAliveInterval=10 -o ServerAliveCountMax=3" \
                 -av --delete site/ \
                 "$SSH_USER@$SSH_HOST:/home/$SSH_USER/$TARGET_HOST/"; then
               echo "Deploy succeeded."

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -14,9 +14,10 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  SSH_HOST: rcpedia-qa.su.domains
-  SSH_USER: rcpediaq
-  SSH_PORT: "22"
+
+# Needed so GITHUB_TOKEN can force-push the built site to the deploy-* branch.
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -81,71 +82,17 @@ jobs:
             echo -e "User-agent: *\nAllow: /" > site/robots.txt
           fi
 
-      - name: Upload Site Artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: site
-          path: site/
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Download Site Artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: site
-          path: site
-
-      - name: Set up SSH
+      # Publish the built site to a per-environment deploy branch. A cPanel cron job on
+      # the Stanford host pulls this branch over HTTPS and rsyncs it into the docroot,
+      # replacing the old inbound SSH/rsync deploy that the firewall now blocks.
+      - name: Publish built site to deploy branch
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.MY_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
-          echo "${{ secrets.MY_SSH_KEY }}" | base64 --decode > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-
-      - name: DNS debug
-        run: |
-          getent hosts "$SSH_HOST" || true
-          dig +short "$SSH_HOST" || true
-
-      - name: Show runner public IP
-        run: |
-          curl -s https://api.ipify.org && echo
-          
-      - name: Deploy to Stanford Hosts (with retries)
-        run: |
-          set -euo pipefail
-      
-          if [[ "${{ github.ref }}" == "refs/heads/QA" ]]; then
-            TARGET_HOST="rcpedia-dev.stanford.edu"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if [ "${{ github.ref }}" = "refs/heads/QA" ]; then
+            B=deploy-qa
           else
-            TARGET_HOST="rcpedia.stanford.edu"
+            B=deploy-main
           fi
-      
-          max_attempts=5
-          delay=15
-      
-          for attempt in $(seq 1 "$max_attempts"); do
-            echo "Deploy attempt $attempt/$max_attempts..."
-      
-            if rsync -e "ssh -i ~/.ssh/id_rsa -p $SSH_PORT -o BatchMode=yes -o ConnectTimeout=120 -o ServerAliveInterval=10 -o ServerAliveCountMax=3" \
-                -av --delete site/ \
-                "$SSH_USER@$SSH_HOST:/home/$SSH_USER/$TARGET_HOST/"; then
-              echo "Deploy succeeded."
-              exit 0
-            fi
-      
-            if [[ "$attempt" -lt "$max_attempts" ]]; then
-              echo "Deploy failed; sleeping ${delay}s..."
-              sleep "$delay"
-              delay=$((delay * 2))
-            else
-              echo "Deploy failed after $max_attempts attempts."
-              exit 1
-            fi
-          done
+          ghp-import -n -f -p -b "$B" -m "deploy ${{ github.sha }}" site

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -88,7 +88,7 @@ jobs:
           path: site/
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: build
     timeout-minutes: 20
 
@@ -106,12 +106,15 @@ jobs:
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.MY_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
-          echo "${{ secrets.MY_SSH_KEY }}" | base64 --decode > ~/.ssh/id_rsa
+          printf '%s\n' "${{ secrets.MY_SSH_KEY }}" | base64 --decode > ~/.ssh/id_rsa || \
+            printf '%s\n' "${{ secrets.MY_SSH_KEY }}" | base64 -D > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
 
       - name: DNS debug
         run: |
-          getent hosts "$SSH_HOST" || true
+          if command -v getent >/dev/null 2>&1; then
+            getent hosts "$SSH_HOST" || true
+          fi
           dig +short "$SSH_HOST" || true
 
       - name: Show runner public IP
@@ -120,7 +123,7 @@ jobs:
 
       - name: Verify SSH connection
         run: |
-          timeout 45s ssh -i ~/.ssh/id_rsa -p "$SSH_PORT" \
+          ssh -i ~/.ssh/id_rsa -p "$SSH_PORT" \
             -o BatchMode=yes \
             -o ConnectTimeout=30 \
             -o ServerAliveInterval=10 \
@@ -143,7 +146,7 @@ jobs:
           for attempt in $(seq 1 "$max_attempts"); do
             echo "Deploy attempt $attempt/$max_attempts..."
       
-            if timeout 300s rsync --timeout=60 -e "ssh -i ~/.ssh/id_rsa -p $SSH_PORT -o BatchMode=yes -o ConnectTimeout=60 -o ServerAliveInterval=10 -o ServerAliveCountMax=3" \
+            if rsync -e "ssh -i ~/.ssh/id_rsa -p $SSH_PORT -o BatchMode=yes -o ConnectTimeout=60 -o ServerAliveInterval=10 -o ServerAliveCountMax=3" \
                 -av --delete site/ \
                 "$SSH_USER@$SSH_HOST:/home/$SSH_USER/$TARGET_HOST/"; then
               echo "Deploy succeeded."

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -90,7 +90,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -117,15 +116,6 @@ jobs:
       - name: Show runner public IP
         run: |
           curl -s https://api.ipify.org && echo
-
-      - name: Verify SSH connection
-        run: |
-          timeout 45s ssh -i ~/.ssh/id_rsa -p "$SSH_PORT" \
-            -o BatchMode=yes \
-            -o ConnectTimeout=30 \
-            -o ServerAliveInterval=10 \
-            -o ServerAliveCountMax=2 \
-            "$SSH_USER@$SSH_HOST" "echo ssh-ok"
           
       - name: Deploy to Stanford Hosts (with retries)
         run: |
@@ -143,14 +133,11 @@ jobs:
           for attempt in $(seq 1 "$max_attempts"); do
             echo "Deploy attempt $attempt/$max_attempts..."
       
-            if timeout 300s rsync --timeout=60 -e "ssh -i ~/.ssh/id_rsa -p $SSH_PORT -o BatchMode=yes -o ConnectTimeout=60 -o ServerAliveInterval=10 -o ServerAliveCountMax=3" \
+            if rsync -e "ssh -i ~/.ssh/id_rsa -p $SSH_PORT -o BatchMode=yes -o ConnectTimeout=120 -o ServerAliveInterval=10 -o ServerAliveCountMax=3" \
                 -av --delete site/ \
                 "$SSH_USER@$SSH_HOST:/home/$SSH_USER/$TARGET_HOST/"; then
               echo "Deploy succeeded."
               exit 0
-            else
-              status=$?
-              echo "Deploy attempt $attempt failed with exit code $status."
             fi
       
             if [[ "$attempt" -lt "$max_attempts" ]]; then

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -90,6 +90,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -116,6 +117,15 @@ jobs:
       - name: Show runner public IP
         run: |
           curl -s https://api.ipify.org && echo
+
+      - name: Verify SSH connection
+        run: |
+          timeout 45s ssh -i ~/.ssh/id_rsa -p "$SSH_PORT" \
+            -o BatchMode=yes \
+            -o ConnectTimeout=30 \
+            -o ServerAliveInterval=10 \
+            -o ServerAliveCountMax=2 \
+            "$SSH_USER@$SSH_HOST" "echo ssh-ok"
           
       - name: Deploy to Stanford Hosts (with retries)
         run: |
@@ -133,11 +143,14 @@ jobs:
           for attempt in $(seq 1 "$max_attempts"); do
             echo "Deploy attempt $attempt/$max_attempts..."
       
-            if rsync -e "ssh -i ~/.ssh/id_rsa -p $SSH_PORT -o BatchMode=yes -o ConnectTimeout=120 -o ServerAliveInterval=10 -o ServerAliveCountMax=3" \
+            if timeout 300s rsync --timeout=60 -e "ssh -i ~/.ssh/id_rsa -p $SSH_PORT -o BatchMode=yes -o ConnectTimeout=60 -o ServerAliveInterval=10 -o ServerAliveCountMax=3" \
                 -av --delete site/ \
                 "$SSH_USER@$SSH_HOST:/home/$SSH_USER/$TARGET_HOST/"; then
               echo "Deploy succeeded."
               exit 0
+            else
+              status=$?
+              echo "Deploy attempt $attempt failed with exit code $status."
             fi
       
             if [[ "$attempt" -lt "$max_attempts" ]]; then

--- a/docs/_policies/user_limits.md
+++ b/docs/_policies/user_limits.md
@@ -33,7 +33,7 @@ Jobs submitted to [Yen Slurm](/_user_guide/slurm/){target="_blank"} have the fol
 | Partition      | CPU Limit Per User | Memory Limit (MB)      | Memory Limit (GB)     | Time Limit (default)  |
 | -------------- | :----------------: | :--------------------: | :-------------------: | :-------------------: |
 |  normal        |    512             |  3072000               | 3000                  | 2 days  (2 hours)     |
-|  long          |    50              |  3072000               | 3000                  | 7 days (2 hours)      |
+|  long          |    256             |  3072000               | 3000                  | 7 days (2 hours)      |
 |  dev           |    2               |  48000                 | 46                    | 2 hours (1 hour)      |
 |  gpu           |    64              |  256000                | 250                    | 1 day (2 hours)       |
 

--- a/docs/_user_guide/slurm.md
+++ b/docs/_user_guide/slurm.md
@@ -327,7 +327,7 @@ The four partitions have the following limits:
 | Partition      | CPU Limit Per User | Memory Limit (MB)      | Memory Limit (GB)     | Time Limit (default)  |
 | -------------- | :----------------: | :--------------------: | :-------------------: | :-------------------: |
 |  normal        |    512             |  3072000               | 3000                  | 2 days  (2 hours)     |
-|  long          |    50              |  3072000               | 3000                  | 7 days (2 hours)      |
+|  long          |    256             |  3072000               | 3000                  | 7 days (2 hours)      |
 |  dev           |    2               |  48000                 | 46                    | 2 hours (1 hour)      |
 |  gpu           |    256              |  768000                | 755                    | 1 day (2 hours)       |
 


### PR DESCRIPTION
Summary: Update the long partition CPU limit from 50 to 256 on the Slurm guide and policy limits page. Validation: git diff --check and venv/bin/python -m mkdocs build --site-dir /tmp/rcpedia-site.