### PR TITLE
Add SSH diagnostics-only pipeline

### DIFF
--- a/.github/workflows/ssh-diagnostics.yml
+++ b/.github/workflows/ssh-diagnostics.yml
@@ -1,0 +1,78 @@
+name: SSH Diagnostics
+
+on:
+  workflow_dispatch:
+    inputs:
+      host:
+        description: 'SSH host to test'
+        required: true
+        default: 'rcpedia-qa.su.domains'
+      user:
+        description: 'SSH user'
+        required: true
+        default: 'rcpediaq'
+      port:
+        description: 'SSH port'
+        required: true
+        default: '22'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  ssh-diagnostics:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.MY_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
+          echo "${{ secrets.MY_SSH_KEY }}" | base64 --decode > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+
+      - name: DNS debug
+        env:
+          HOST: ${{ inputs.host }}
+        run: |
+          getent hosts "$HOST" || true
+          dig +short "$HOST" || true
+
+      - name: Show runner public IP
+        run: |
+          curl -s https://api.ipify.org && echo
+
+      - name: TCP port check
+        env:
+          HOST: ${{ inputs.host }}
+          PORT: ${{ inputs.port }}
+        run: |
+          nc -vz -w 10 "$HOST" "$PORT" || true
+
+      - name: ssh-keyscan
+        env:
+          HOST: ${{ inputs.host }}
+          PORT: ${{ inputs.port }}
+        run: |
+          ssh-keyscan -p "$PORT" -T 10 "$HOST" || true
+
+      - name: SSH auth test
+        env:
+          HOST: ${{ inputs.host }}
+          USER: ${{ inputs.user }}
+          PORT: ${{ inputs.port }}
+        run: |
+          ssh -vvv -i ~/.ssh/id_rsa -p "$PORT" \
+            -o BatchMode=yes -o ConnectTimeout=120 \
+            -o ServerAliveInterval=10 -o ServerAliveCountMax=3 \
+            "$USER@$HOST" 'echo SSH_OK; hostname; whoami; pwd' || true
+
+      - name: rsync dry-run
+        env:
+          HOST: ${{ inputs.host }}
+          USER: ${{ inputs.user }}
+          PORT: ${{ inputs.port }}
+        run: |
+          rsync -e "ssh -i ~/.ssh/id_rsa -p $PORT -o BatchMode=yes -o ConnectTimeout=120 -o ServerAliveInterval=10 -o ServerAliveCountMax=3" \
+            -avn --list-only \
+            "$USER@$HOST:/home/$USER/" || true


### PR DESCRIPTION
## What

Adds a new, standalone GitHub Actions workflow — **SSH Diagnostics** (`.github/workflows/ssh-diagnostics.yml`) — that runs *only* SSH connectivity checks. No build, no artifact, no deploy, and nothing is written to any server.

## Why

The `deploy` job in `pipeline.yml` (`DeployStanford`) periodically hits SSH/network trouble (hence its retry logic, DNS debug, and public-IP check). This pipeline isolates just the SSH path so those failures can be debugged without running a full build + deploy.

## How it works

- **Manual-only trigger** (`workflow_dispatch`) with inputs supplied at run time so you can try different targets:
  - `host` (default `rcpedia-qa.su.domains`)
  - `user` (default `rcpediaq`)
  - `port` (default `22`)
- **Steps**, in order:
  1. **Set up SSH** — reuses the deploy job's setup (decodes `MY_SSH_KEY`, writes `MY_KNOWN_HOSTS`)
  2. **DNS debug** — `getent` + `dig`
  3. **Show runner public IP** — via `api.ipify.org`
  4. **TCP port check** — `nc -vz` (network/firewall vs. auth)
  5. **ssh-keyscan** — shows host keys the server presents (`known_hosts` mismatches)
  6. **SSH auth test** — `ssh -vvv` with the same `BatchMode`/`ConnectTimeout`/`ServerAlive*` options the deploy uses
  7. **rsync dry-run** — `rsync -avn --list-only` (no `--delete`, no write) over the same transport as the real deploy

Every probe ends with `|| true` so one failure doesn't hide later output.

## Note

`workflow_dispatch` workflows only appear under *Run workflow* in the Actions tab once the file is on the default branch, so this must merge to `main` before it can be triggered from the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)