### PR TITLE
Version-control deploy tooling + document pull-based deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,13 @@ git pull origin <branch_name>
 
 View the changes locally. Assuming you have a venv described above, activate it and run “mkdocs serve”.
 
+## Deployment
+
+Merging to `QA` (→ https://rcpedia-dev.stanford.edu) or `main` (→ https://rcpedia.stanford.edu)
+triggers the GitHub Actions workflow, which builds the site and publishes it for the Stanford
+host to pull. Deploys are **pull-based**: GitHub publishes the built site to a `deploy-qa` /
+`deploy-main` branch, and a cron job on the host syncs it into the docroot (the old inbound SSH
+deploy is blocked by a Stanford firewall change). Propagation takes up to ~5 minutes.
+
+See [`deploy/README.md`](deploy/README.md) for the mechanism, server setup, and rollback steps.
+

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,70 @@
+# Deployment (pull-based)
+
+The rcpedia site is **pulled** onto the Stanford host, not pushed.
+
+## Why
+
+The old pipeline pushed the built site **inbound over SSH/rsync (port 22)** from GitHub's
+cloud runners to the host. A Stanford firewall change now blocks inbound SSH from GitHub's
+runner IP ranges, and the provider won't allowlist. Outbound HTTPS from the host to GitHub
+still works, so we invert the flow: GitHub publishes the built site to a branch, and the
+host pulls it.
+
+## How it works
+
+1. `.github/workflows/pipeline.yml` builds the site on every push to `main`/`QA`, then
+   force-pushes the built `site/` to a per-environment branch with `ghp-import`:
+   - `QA`  → `deploy-qa`
+   - `main` → `deploy-main`
+2. A cron job on the **`rcpediaq`** cPanel account runs [`pull-deploy.sh`](pull-deploy.sh),
+   which fetches the deploy branch over HTTPS (public repo, no token) and rsyncs it into the
+   docroot, keeping a one-generation backup for rollback:
+   - `deploy-qa`   → `~/rcpedia-dev.stanford.edu`  → https://rcpedia-dev.stanford.edu
+   - `deploy-main` → `~/rcpedia.stanford.edu`      → https://rcpedia.stanford.edu
+
+This file is the source of truth for the script. It lives under `deploy/` (outside `docs/`),
+so it is never built into the site or included in the `deploy-*` branches.
+
+## One-time server setup (as `rcpediaq`, in cPanel Terminal)
+
+```bash
+mkdir -p ~/deploy
+# copy pull-deploy.sh from this repo to ~/deploy/pull-deploy.sh, then:
+chmod +x ~/deploy/pull-deploy.sh
+bash ~/deploy/pull-deploy.sh    # first run: clones the deploy branches and populates docroots
+```
+
+Add a cron job in **cPanel → Cron Jobs** (every 5 minutes):
+
+```
+*/5 * * * * flock -n $HOME/deploy/.lock -c "/bin/bash $HOME/deploy/pull-deploy.sh" >> $HOME/deploy/deploy.log 2>&1
+```
+
+`flock -n` prevents overlapping runs. For an immediate deploy (e.g. right after a merge),
+run `bash ~/deploy/pull-deploy.sh` manually — it is idempotent.
+
+## Updating the script
+
+The repo copy is canonical. When it changes, copy it to `~/deploy/pull-deploy.sh` on the
+`rcpediaq` account. (The script changes rarely, so this manual sync is intentional; it can
+be automated later with a self-updating server clone if needed.)
+
+## Rollback
+
+The live site is static files, so a bad build/cron never takes it down — only stops updates.
+
+1. **Freeze:** disable the cron job in cPanel. The current docroot keeps serving.
+2. **Instant undo (no rebuild):** restore the previous docroot from the backup the script keeps:
+   ```bash
+   rsync -a --delay-updates --delete-after ~/deploy/prev-deploy-qa/ ~/rcpedia-dev.stanford.edu/
+   # (use prev-deploy-main / rcpedia.stanford.edu for prod)
+   ```
+3. **Forward-fix (normal path):** `git revert <bad-commit>` on `QA`/`main` and push; the
+   pipeline rebuilds and republishes, and cron pulls it within ~5 min.
+
+## Host constraints (for reference)
+
+- Outbound HTTPS to GitHub works; **inbound SSH is firewall-blocked**.
+- Long-lived processes are reaped on this shared host, so a persistent self-hosted runner is
+  not viable — hence cron.
+- Both docroots live on the single `rcpediaq` account (not a personal account like `astorers`).

--- a/deploy/pull-deploy.sh
+++ b/deploy/pull-deploy.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Pull-based deploy for the rcpedia site.
+#
+# The GitHub Actions workflow (.github/workflows/pipeline.yml) builds the site and
+# force-pushes it to a per-environment branch: QA -> deploy-qa, main -> deploy-main.
+# This script runs from cron on the `rcpediaq` cPanel account, fetches those branches
+# over outbound HTTPS (the Stanford firewall blocks the old inbound SSH deploy), and
+# rsyncs them into the docroots. See deploy/README.md for setup.
+#
+set -euo pipefail
+REPO="https://github.com/gsbdarc/rcpedia.git"
+
+deploy() {
+  local branch="$1"
+  local docroot="$2"
+  local src="$HOME/deploy/src-$branch"
+  local marker="$HOME/deploy/.deployed-$branch"
+
+  [ -d "$docroot" ] || { echo "SKIP: docroot $docroot missing"; return 0; }
+
+  # Skip cleanly if the deploy branch doesn't exist yet (e.g. before prod rollout).
+  if ! git ls-remote --exit-code --heads "$REPO" "$branch" >/dev/null 2>&1; then
+    echo "SKIP: remote branch $branch not found"; return 0
+  fi
+
+  if [ ! -d "$src/.git" ]; then
+    git clone --branch "$branch" --single-branch --depth 1 "$REPO" "$src"
+  fi
+  cd "$src"
+  git fetch --depth 1 origin "$branch"
+  git reset --hard FETCH_HEAD >/dev/null
+  local sha
+  sha="$(git rev-parse HEAD)"
+
+  # Deploy when this commit hasn't been deployed yet (marker missing or stale) —
+  # a marker (not HEAD-vs-remote) is required so the FIRST run after a fresh clone,
+  # where HEAD already equals the tip, still deploys.
+  if [ -f "$marker" ] && [ "$(cat "$marker")" = "$sha" ]; then
+    return 0
+  fi
+
+  # One-generation backup of the live docroot for instant rollback.
+  if [ -n "$(ls -A "$docroot" 2>/dev/null)" ]; then
+    rm -rf "$HOME/deploy/prev-$branch"
+    cp -a "$docroot" "$HOME/deploy/prev-$branch"
+  fi
+  # --delay-updates: stage new files, flip them in together at the end (near-atomic)
+  # --delete-after: remove stale files AFTER transfers, never before their replacement
+  #                 (--delete-after works on older rsync; --delete-delayed needs rsync 3.0+)
+  rsync -a --delay-updates --delete-after --exclude='.git' "$src/" "$docroot/"
+  echo "$sha" > "$marker"
+  echo "$(date) deployed $branch@$sha -> $docroot"
+}
+
+deploy deploy-qa   "$HOME/rcpedia-dev.stanford.edu"
+deploy deploy-main "$HOME/rcpedia.stanford.edu"


### PR DESCRIPTION
Adds the cPanel-side deploy tooling to the repo as the source of truth, and documents the pull-based deploy.

## Changes
- `deploy/pull-deploy.sh` — the cron-run pull script (canonical copy of what runs on the `rcpediaq` account).
- `deploy/README.md` — mechanism, one-time server setup, the cron line, and rollback steps.
- `README.md` — new **Deployment** section pointing at `deploy/README.md`.

`deploy/` lives outside `docs/`, so it is never built into the site or the `deploy-*` branches (verified: existing top-level dirs like `instructions/` don't appear in `site/`).

Part of #249.