### PR TITLE
Update home quota docs from 50G to 80G

### DIFF
--- a/docs/_policies/user_limits.md
+++ b/docs/_policies/user_limits.md
@@ -44,7 +44,7 @@ The maximum job array size is set to **512** on Yen-Slurm.
 
 ## Storage Limits
 
-Home directories have a limit of 50G, and are designed to store personal files, not project work. Learn more about [storage on the Yens](/_user_guide/storage/#yen-file-system){target="_blank"}.
+Home directories have a limit of 80G, and are designed to store personal files, not project work. Learn more about [storage on the Yens](/_user_guide/storage/#yen-file-system){target="_blank"}.
 
 !!! danger "Do NOT exceed your quota!"
     If you exceed your home directory quota, you cannot access Jupyter or perform many basic system tasks.
@@ -55,7 +55,10 @@ gsbquota
 ```
 You will see the space used in your home directory:
 ```{.yaml .no-copy title="Terminal Output"}
-/home/users/$USER: currently using X% (XG) of 50G available
+/home/users/$USER:
+  using X% (XGiB) of soft quota 80GiB
+  hard quota: 300GiB
+  time until lockout: no block scheduled
 ```
 
 ### Identifying Large Files

--- a/docs/_user_guide/data_transfer.md
+++ b/docs/_user_guide/data_transfer.md
@@ -10,7 +10,7 @@ If you’re working with smaller files, the most straightforward method is to tr
 ![Uploading files via JupyterHub](/assets/images/data_transfer_jupyterhub_upload.png){:target="_blank"}
 
 !!! danger "Do Not Exceed Your Quota!"
-	Your home directory has a 50 GB limit. If you exceed that limit, you will no longer be able to access JupyterHub.
+	Your home directory has an 80 GB limit. If you exceed that limit, you will no longer be able to access JupyterHub.
 
 ## SCP
 

--- a/docs/_user_guide/monitor_usage.md
+++ b/docs/_user_guide/monitor_usage.md
@@ -28,7 +28,7 @@ Please refer to our [Parallel Processing in R](/_user_guide/parallel_processing_
 Be sure to monitor your processes, particularly when using a new package, to verify that you are using the expected number of cores.
 
 ## Monitoring Disk Usage
-Personal home directories have a 50 GB quota, while faculty [project directories](/_user_guide/storage){target="_blank"} are much larger. 
+Personal home directories have an 80 GB quota, while faculty [project directories](/_user_guide/storage){target="_blank"} are much larger. 
 
 !!! danger "Do NOT Exceed Your Home Directory Quota!"
     If you exceed your home directory quota, you cannot access Jupyter or perform many basic system tasks.
@@ -44,7 +44,10 @@ gsbquota
 ```
 
 ```{.yaml .no-copy title="Terminal Output"}
-currently using 39% (20G) of 50G available
+/home/users/$USER:
+  using 39% (31GiB) of soft quota 80GiB
+  hard quota: 300GiB
+  time until lockout: no block scheduled
 ```
 
 You can also check the size of your project space by passing in a full path to your project space to `gsbquota` command:

--- a/docs/_user_guide/storage.md
+++ b/docs/_user_guide/storage.md
@@ -241,7 +241,7 @@ gsbquota
 Example output:
 ```{ .yaml .no-copy title="Terminal Output" }
 /home/users/<SUNet ID>:
-  using 52% (43GiB) of soft quota 80GiB
+  using 56% (46GiB) of soft quota 80GiB
   hard quota: 300GiB
   time until lockout: no block scheduled
 ```

--- a/docs/assets/announcement.json
+++ b/docs/assets/announcement.json
@@ -1,6 +1,6 @@
 {
-    "type": "",
-    "message": "",
+    "type": "ALERT",
+    "message": "⚠️ Scheduled Downtime: <b>Thursday, July 23, 2026</b>. All Yen servers will be offline for the day ⚠️.",
     "examples": [
         {
             "type": "ERROR",


### PR DESCRIPTION
## Summary
- Home directory soft quota increased from 50G to 80G; updated all docs pages mentioning the old limit (user_limits.md, monitor_usage.md, data_transfer.md).
- Refreshed `gsbquota` example output across pages to match the current multi-line format (soft quota / hard quota / time until lockout).

## Test plan
- [x] Verified no remaining home-quota references to 50G in docs (Google Drive and GPU RAM mentions of "50G"/"750G" are unrelated and untouched).
- [x] Confirmed QA build (deploy-qa) rendered the updated content correctly on rcpedia-dev.