### PR TITLE
Remove past downtime banner (July 23, 2026)

### DIFF
--- a/docs/assets/announcement.json
+++ b/docs/assets/announcement.json
@@ -1,6 +1,6 @@
 {
-    "type": "ALERT",
-    "message": "⚠️ Scheduled Downtime: <b>Thursday, July 23, 2026</b>. All Yen servers will be offline for the day ⚠️.",
+    "type": "",
+    "message": "",
     "examples": [
         {
             "type": "ERROR",


### PR DESCRIPTION
## Summary
The scheduled downtime announcement for **Thursday, July 23, 2026** has passed, so this clears the stale banner.

- Sets the top-level `type` and `message` in `docs/assets/announcement.json` back to empty strings.
- The banner-rendering logic (`docs/js/announcement-banner.js`) hides the banner when `message`/`type` are empty, so no banner renders.
- The `examples` template array is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)