### PR TITLE
Document per-user scratch space (/scratch/users/$SUNET)

### DIFF
--- a/docs/_user_guide/storage.md
+++ b/docs/_user_guide/storage.md
@@ -179,7 +179,10 @@ Use `/scratch/shared` when:
 
 ---
 
-##### 🔒 Using Scratch Safely 
+##### 🔒 Using Shared Scratch Safely 
+
+!!! note "Per-user scratch needs no setup"
+    These permission steps apply to **`/scratch/shared` only**. Your per-user scratch (`/scratch/users/$SUNET`) is private by default, so you can skip this section for it.
 
 By default, files in `/scratch/shared` may be visible to other users unless you restrict access.
 
@@ -251,17 +254,21 @@ python script.py
 
 ---
 
-##### 🧹Clean Up Your Scratch Space
-Scratch is a shared, temporary resource. You are expected to remove your files when your job is complete.
+#### 🧹 Cleaning Up Scratch Space
+Scratch is a temporary resource. You are expected to remove your files when your job is complete.
 
-To clean up your scratch directory:
+To clean up your scratch directories:
 
 ```bash title="Terminal Command"
+# per-user scratch
+rm -rf /scratch/users/$SUNET/*
+
+# shared scratch
 rm -rf /scratch/shared/$USER/*
 ``` 
 
-!!! warning "Always move results back to permanent storage"
-      - Files in `/scratch/shared` are not backed up and may be periodically cleared by administrators. Any important results should be moved to your project directory. 
+!!! warning "Scratch is not backed up and will be cleared"
+      Files on scratch are not backed up and **will** be periodically cleared. Per-user scratch (`/scratch/users/$SUNET`) is cleared at each scheduled downtime (about every two months) for files older than **90 days**; shared scratch (`/scratch/shared`) is cleared by administrators. Move any important results to your [project directory](#project-directory){:target="_blank"}.
 
 ## How to Check Home and Project Space Quota
 

--- a/docs/_user_guide/storage.md
+++ b/docs/_user_guide/storage.md
@@ -93,6 +93,7 @@ If you would like to discuss specific storage solutions for your project, please
 Some workflows require fast, short-term storage for intermediate results. The Yen cluster provides two options:
 
 - Node-local storage: `/tmp`
+- Per-user scratch space: `/scratch/users/$SUNET`
 - Shared scratch space: `/scratch/shared`
 
 These locations are **not intended for permanent data** and are **not backed up**.
@@ -122,6 +123,38 @@ Use `/tmp` when:
       - `/tmp` is cleared when the job is done and when the node reboots. Always copy important results back to your project directory.
       - Avoid filling `/tmp`. Other jobs on the same node depend on it.
 
+
+#### Per-User Scratch
+
+Each user also has a **private, per-user scratch directory** on the shared VAST file system, created automatically at:
+
+```{ .yaml .no-copy title="Terminal Output" }
+/scratch/users/$SUNET
+```
+
+This space is:
+
+- Private to you and created automatically
+- Large — up to **100 TB** of shared scratch capacity
+- Accessible from all Yen nodes
+- Slower than `/tmp`
+
+Unlike `/scratch/shared`, your per-user scratch is private by default, so you do not need to set permissions manually.
+
+Check your scratch usage by passing the path to the `gsbquota` command:
+
+```bash title="Terminal Command"
+gsbquota /scratch/users/$SUNET
+```
+
+```{ .yaml .no-copy title="Terminal Output" }
+/scratch/users/<SUNetID>: currently using 22% (22T) of 100T available
+```
+
+!!! warning "Per-user scratch is cleared periodically"
+    Per-user scratch is temporary and **not backed up**. At each scheduled downtime (about every two months), files older than **90 days** are automatically deleted. Move anything you want to keep to your [project directory](#project-directory){:target="_blank"}.
+
+---
 
 #### Cluster-Wide Scratch
 

--- a/docs/_user_guide/storage.md
+++ b/docs/_user_guide/storage.md
@@ -268,7 +268,7 @@ rm -rf /scratch/shared/$USER/*
 ``` 
 
 !!! warning "Scratch is not backed up and will be cleared"
-      Files on scratch are not backed up and **will** be periodically cleared. Per-user scratch (`/scratch/users/$SUNET`) is cleared at each scheduled downtime (about every two months) for files older than **90 days**; shared scratch (`/scratch/shared`) is cleared by administrators. Move any important results to your [project directory](#project-directory){:target="_blank"}.
+      Files on scratch are not backed up and **will** be periodically cleared. `/scratch` files older than **90 days** are deleted at each scheduled downtime (about every two months). Move any important results to your [project directory](#project-directory){:target="_blank"}.
 
 ## How to Check Home and Project Space Quota
 


### PR DESCRIPTION
## Summary
Documents the new **per-user scratch** space at `/scratch/users/$SUNET`, added alongside the existing shared scratch in `docs/_user_guide/storage.md`.

- New `#### Per-User Scratch` subsection under Temporary Storage, placed **above** Cluster-Wide Scratch.
- Private, auto-created directory on the shared **VAST** file system.
- Up to **100 TB total** shared scratch capacity; accessible from all Yen nodes; slower than `/tmp`.
- `gsbquota /scratch/users/$SUNET` usage example.
- Cleanup policy: at each scheduled downtime (~every two months), files older than **90 days** are deleted.
- Reordered the Temporary Storage intro list to include per-user scratch.

Verified locally with `mkdocs serve` — renders correctly under Temporary Storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)