### PR TITLE
Add AI Coding Agents page and DUA responsibility warnings

### DIFF
--- a/docs/_getting_started/modules.md
+++ b/docs/_getting_started/modules.md
@@ -115,9 +115,9 @@ module load <module_name>
 
 !!! danger "AI Agents Carry Data Responsibilities"
     AI coding agents such as `claude-code`, `gemini`, and `codex` are available as modules.
-    These tools send the files they can access to external providers, and their usage is
-    audited. It is **your** responsibility to know what data may be shared with AI tools and
-    to keep data covered by a signed DUA or NDA out of them. See
+    These tools send the files they can access to external providers. It is **your**
+    responsibility to know what data may be shared with AI tools and to keep data covered
+    by a signed DUA or NDA out of them. See
     [AI Coding Agents](/_user_guide/ai_agents/){target="_blank"} before loading these modules,
     and contact
     [gsb-library_research-data-coordination@stanford.edu](mailto:gsb-library_research-data-coordination@stanford.edu){target="_blank"}

--- a/docs/_getting_started/modules.md
+++ b/docs/_getting_started/modules.md
@@ -114,7 +114,7 @@ module load <module_name>
     You may also use the `ml` command as a shorthand for `module load`.
 
 !!! danger "AI Agents Carry Data Responsibilities"
-    AI coding agents such as `claude-code`, `gemini`, and `codex` are available as modules.
+    AI coding agents such as `claude-code`, `codex`, and `gemini` are available as modules.
     These tools send the files they can access to external providers. It is **your**
     responsibility to know what data may be shared with AI tools and to keep data covered
     by a signed DUA or NDA out of them. See

--- a/docs/_getting_started/modules.md
+++ b/docs/_getting_started/modules.md
@@ -13,8 +13,12 @@ Here's a list of software packages currently available on the Yen servers:
 - AWS CLI
 - Bats
 - Bbcp
+- Claude Code
+- Codex
 - Dotnet
 - Emacs
+- Gemini CLI
+- GitHub CLI
 - Google Cloud
 - Google Drive
 - Go
@@ -108,6 +112,16 @@ module load <module_name>
 
 !!! Tip
     You may also use the `ml` command as a shorthand for `module load`.
+
+!!! danger "AI Agents Carry Data Responsibilities"
+    AI coding agents such as `claude-code`, `gemini`, and `codex` are available as modules.
+    These tools send the files they can access to external providers, and their usage is
+    audited. It is **your** responsibility to know what data may be shared with AI tools and
+    to keep data covered by a signed DUA or NDA out of them. See
+    [AI Coding Agents](/_user_guide/ai_agents/){target="_blank"} before loading these modules,
+    and contact
+    [gsb-library_research-data-coordination@stanford.edu](mailto:gsb-library_research-data-coordination@stanford.edu){target="_blank"}
+    with any questions.
 
 For example, to load R, run:
     

--- a/docs/_policies/security.md
+++ b/docs/_policies/security.md
@@ -49,14 +49,14 @@ If you are using licensed data, the storage, processing, sharing and publication
 
 For data licensed by the GSB Library, please refer to this [eResources Guide](https://www.gsb.stanford.edu/library/research-resources/usage-policy) for additional requirements including limitations on scraping, sharing credentials and external distribution.
 
-If you have any questions or concerns about use of your data, please [contact the GSB Research Hub library and data governance team](mailto:gsb-library_research-data-coordination@stanford.edu){:target="_blank"} to discuss your specific situation.
+If you have any questions or concerns about use of your data, please contact the [GSB Data Acquisition and Governance team](https://gsbresearchhub.stanford.edu/support-units/data-acquisition-and-governance){:target="_blank"} at [gsb-library_research-data-coordination@stanford.edu](mailto:gsb-library_research-data-coordination@stanford.edu){:target="_blank"} to discuss your specific situation.
 
 ## AI Tooling, Claude Code & Cursor
 
 When working with AI tools, there are additional considerations for researchers.
 
 !!! note "Using AI Coding Agents on the Yens"
-    AI coding agents such as `claude-code`, `gemini`, and `codex` are installed as modules on the Yens. For how to load and use them — and your data-governance responsibilities — see [AI Coding Agents](/_user_guide/ai_agents/){:target="_blank"}.
+    AI coding agents such as `claude-code`, `codex`, and `gemini` are installed as modules on the Yens. For how to load and use them — and your data-governance responsibilities — see [AI Coding Agents](/_user_guide/ai_agents/){:target="_blank"}.
 
 !!! danger "University Approved Systems"
     Stanford's Information Security Office maintains a list of reviewed and approved (or discouraged) services at the [GenAI Tool Evaluation Matrix](https://uit.stanford.edu/ai/genai-tool-matrix){:target="_blank"}.
@@ -64,7 +64,7 @@ When working with AI tools, there are additional considerations for researchers.
 
 ### Licensed Data
 
-Data licenses can have specific clauses about where the data can be stored, as well as the degree to which AI can (or can't) be used on that data. When we license these data sets, it's important that we do our best to follow those licenses, which can sometimes require some interpretation or guidance. If you have any questions or concerns about using AI with your data, please [contact the GSB Research Hub library and data governance team](mailto:gsb-library_research-data-coordination@stanford.edu){:target="_blank"}.
+Data licenses can have specific clauses about where the data can be stored, as well as the degree to which AI can (or can't) be used on that data. When we license these data sets, it's important that we do our best to follow those licenses, which can sometimes require some interpretation or guidance. If you have any questions or concerns about using AI with your data, please contact the [GSB Data Acquisition and Governance team](https://gsbresearchhub.stanford.edu/support-units/data-acquisition-and-governance){:target="_blank"} at [gsb-library_research-data-coordination@stanford.edu](mailto:gsb-library_research-data-coordination@stanford.edu){:target="_blank"}.
 
 ### Configuration Matters
 

--- a/docs/_policies/security.md
+++ b/docs/_policies/security.md
@@ -49,11 +49,14 @@ If you are using licensed data, the storage, processing, sharing and publication
 
 For data licensed by the GSB Library, please refer to this [eResources Guide](https://www.gsb.stanford.edu/library/research-resources/usage-policy) for additional requirements including limitations on scraping, sharing credentials and external distribution.
 
-If you have any questions or concerns about use of your data, please [contact the Research Hub](mailto:gsb-library_research-data-coordination@stanford.edu){:target="_blank"} to discuss your specific situation.
+If you have any questions or concerns about use of your data, please [contact the GSB Research Hub library and data governance team](mailto:gsb-library_research-data-coordination@stanford.edu){:target="_blank"} to discuss your specific situation.
 
 ## AI Tooling, Claude Code & Cursor
 
 When working with AI tools, there are additional considerations for researchers.
+
+!!! note "Using AI Coding Agents on the Yens"
+    AI coding agents such as `claude-code`, `gemini`, and `codex` are installed as modules on the Yens. For how to load and use them — and your data-governance responsibilities — see [AI Coding Agents](/_user_guide/ai_agents/){:target="_blank"}.
 
 !!! danger "University Approved Systems"
     Stanford's Information Security Office maintains a list of reviewed and approved (or discouraged) services at the [GenAI Tool Evaluation Matrix](https://uit.stanford.edu/ai/genai-tool-matrix){:target="_blank"}.
@@ -61,21 +64,11 @@ When working with AI tools, there are additional considerations for researchers.
 
 ### Licensed Data
 
-Data licenses can have specific clauses about where the data can be stored, as well as the degree to which AI can (or can't) be used on that data. When we license these data sets, it's important that we do our best to follow those licenses, which can sometimes require some interpretation or guidance. If you have any questions or concerns about using AI with your data, please [contact the Research Hub](mailto:gsb-library_research-data-coordination@stanford.edu){:target="_blank"}.
+Data licenses can have specific clauses about where the data can be stored, as well as the degree to which AI can (or can't) be used on that data. When we license these data sets, it's important that we do our best to follow those licenses, which can sometimes require some interpretation or guidance. If you have any questions or concerns about using AI with your data, please [contact the GSB Research Hub library and data governance team](mailto:gsb-library_research-data-coordination@stanford.edu){:target="_blank"}.
 
 ### Configuration Matters
 
 Tools like Cursor and Claude Code work by scanning the files they have access to. It is imperative that you know which files are being provided to these tools, and that you provide only the files that these tools need. If Cursor inadvertently is granted access to a data directory, for instance, that data may be sent to a third party server and stored and processed in unexpected ways. Consider isolating these tools, potentially including running them in a containerized environment that provides another layer of data isolation. If possible, you may be able to configure these tools to emit verbose logs of the actions they take, so that you can confirm that they are only scanning the files that you intend, and save the logs for any potential auditing in the event that a data provider raises concerns in the future. In addition, you can request that these tools do not store your data -- the configurations vary by tool, but whenever possible you should be providing as little code, data and personal information to these tools.
-
-### Other Tooling can Help
-
-Claude Code and Cursor are complicated tools, but at their core is one or more large language models. You may be able to use a specific model from, e.g., Stanford's managed [AI API Gateway](https://uit.stanford.edu/service/ai-api-gateway){:target="_blank"}, which can reduce your exposure risk. These tools have been vetted by Stanford IT for data security, and will give you an API key that is billed directly back to a Stanford account. In general, it is preferred to use Stanford's tools or locally installed tools to expose as little data as possible.
-
-### Data Risk
-
-Stanford categorizes data risk into three broad categories, low (mostly public data), moderate (mostly private data) and high (data that comes with legal ramifications). High risk data needs to be treated with extreme caution, and if you're using any amount of high risk data, you should avoid using any tools except those explicitly reviewed and approved by Stanford's IT department. Even if you're not using high risk data with Claude Code or Cursor, storing it on the same system means that misconfiguration or accidents could expose the university to legal consequences. 
-
-
 
 ## Information Security
 

--- a/docs/_user_guide/ai_agents.md
+++ b/docs/_user_guide/ai_agents.md
@@ -2,8 +2,8 @@
 
 Several AI coding agents are available on the Yens as modules, including
 [Claude Code](https://docs.claude.com/en/docs/claude-code/overview){target="_blank"},
-[Gemini CLI](https://google-gemini.github.io/gemini-cli/){target="_blank"}, and
-[Codex CLI](https://developers.openai.com/codex/cli/){target="_blank"}. These are agentic
+[Codex CLI](https://developers.openai.com/codex/cli/){target="_blank"}, and
+[Gemini CLI](https://google-gemini.github.io/gemini-cli/){target="_blank"}. These are agentic
 command-line tools: they read files in your working directory, run commands on your behalf,
 and send that context to an external model provider to generate responses.
 
@@ -58,14 +58,14 @@ To use an agent, load its module:
     ml claude-code
     ```
 
-=== "Gemini CLI"
-    ```title="Terminal Input"
-    ml gemini
-    ```
-
 === "Codex"
     ```title="Terminal Input"
     ml codex
+    ```
+
+=== "Gemini CLI"
+    ```title="Terminal Input"
+    ml gemini
     ```
 
 This loads the default version. To pin a specific one:
@@ -103,6 +103,27 @@ project directory that contains only the files the tool needs, never from a dire
 also holds restricted or licensed data. See
 [Configuration Matters](/_policies/security/#configuration-matters){target="_blank"} for
 guidance on isolating these tools.
+
+## Codex
+
+[Codex CLI](https://developers.openai.com/codex/cli/){target="_blank"} is OpenAI's agentic
+coding tool. With the module loaded, launch it:
+
+```title="Terminal Input"
+codex
+```
+
+### Authenticating
+
+Codex is available to Stanford users through Stanford's
+[**ChatGPT Edu**](https://uit.stanford.edu/service/openai-chatgpt-edu){target="_blank"}
+service, which covers use of the CLI. When you first run `codex`, sign in with your **Stanford account**.
+
+This is the recommended route — your usage falls under Stanford's agreement with OpenAI. To
+use Stanford's AI API Gateway instead, see
+[Using the AI API Gateway](#using-the-ai-api-gateway) below.
+
+As with the other agents, run Codex from a directory scoped to only the files the tool needs.
 
 ## Gemini
 
@@ -146,43 +167,13 @@ or the [Stanford AI Playground](https://uit.stanford.edu/aiplayground){target="_
 directly. See [University IT AI](https://uit.stanford.edu/ai){target="_blank"} for the full
 list of Stanford's AI services.
 
-## Codex
-
-[Codex CLI](https://developers.openai.com/codex/cli/){target="_blank"} is OpenAI's agentic
-coding tool. With the module loaded, launch it:
-
-```title="Terminal Input"
-codex
-```
-
-### Authenticating
-
-Codex is available to Stanford users through Stanford's
-[**ChatGPT Edu**](https://uit.stanford.edu/service/openai-chatgpt-edu){target="_blank"}
-service, which covers use of the CLI. When you first run `codex`, sign in with your **Stanford account**.
-
-This is the recommended route — your usage falls under Stanford's agreement with OpenAI. To
-use Stanford's AI API Gateway instead, see
-[Using the AI API Gateway](#using-the-ai-api-gateway) below.
-
-As with the other agents, run Codex from a directory scoped to only the files the tool needs.
-
 ## Using the AI API Gateway
 
 Stanford's [AI API Gateway](https://uit.stanford.edu/service/ai-api-gateway){target="_blank"}
 is a different way to reach these models: an **OpenAI-compatible API** you call from your own
-code, rather than a way to sign in to an agent.
-[Request a key](https://stanford.service-now.com/it_services?id=sc_cat_item&sys_id=fd75ec563b90265079a53434c3e45a65){target="_blank"},
-pick a model from Stanford's list, and POST to
-`https://aiapi-prod.stanford.edu/v1/chat/completions` with your key as a bearer token. It
-covers models from Anthropic, OpenAI, and Google under Stanford's terms.
-
-!!! warning "The Gateway Charges for Every Call"
-    Unlike signing in with your Stanford account, the Gateway is a **chargeback service**: you
-    pay per API call, priced by input and output tokens, and it bills monthly against a
-    **PTA**. Rates vary by model and change often — check the current
-    [AI API Gateway rates](https://uit.stanford.edu/service/ai-api-gateway/rates){target="_blank"}
-    before you start, and set a maximum monthly budget when you request your key.
+code, rather than a way to sign in to an agent. See
+[Stanford's LLM API Tools](/blog/2026/03/06/stanfords-llm-api-tools/){target="_blank"} for how
+to request a key and start making calls.
 
 For the agents on this page, signing in with your Stanford account is simpler and is already
 covered by Stanford's agreements. If you do want to route an agent through the Gateway, each
@@ -190,8 +181,6 @@ one needs its own configuration — follow Stanford's setup guides for
 [Claude Code](https://uit.stanford.edu/service/ai-api-gateway/userguide/claude-cli-setup){target="_blank"}
 and
 [Codex CLI](https://uit.stanford.edu/service/ai-api-gateway/userguide/openai-codex-cli-setup){target="_blank"}.
-The Gemini CLI cannot use the Gateway at all, since the Gateway exposes nothing in Google's
-API format.
 
 ## Your Responsibilities
 

--- a/docs/_user_guide/ai_agents.md
+++ b/docs/_user_guide/ai_agents.md
@@ -93,14 +93,9 @@ Claude Code is available to Stanford users through Stanford's
 which covers use of the CLI. When you first run `claude`, follow the prompts to sign
 in with your **Stanford account**.
 
-Alternatively, you can route Claude Code through Stanford's
-[AI API Gateway](https://uit.stanford.edu/service/ai-api-gateway){target="_blank"}. A key on
-its own is not enough: Claude Code sends requests to Anthropic unless you also point it at the
-Gateway with `ANTHROPIC_BASE_URL`, and because the Gateway authenticates with a bearer token,
-the credential goes in `ANTHROPIC_AUTH_TOKEN` rather than `ANTHROPIC_API_KEY`. Follow
-Stanford's
-[Claude Code CLI setup guide](https://uit.stanford.edu/service/ai-api-gateway/userguide/claude-cli-setup){target="_blank"}
-(Stanford login required) for the current base URL and values.
+This is the recommended route — your usage falls under Stanford's agreement with Anthropic. To
+use Stanford's AI API Gateway instead, see
+[Using the AI API Gateway](#using-the-ai-api-gateway) below.
 
 Claude Code works by scanning the files it has access to, starting from the directory where
 you launch it. **Be deliberate about which directory you run it in** — launch it from a
@@ -144,12 +139,9 @@ This is a **personal** key, and on Google's
 [free tier](https://ai.google.dev/gemini-api/terms){target="_blank"} your prompts and
 responses may be read by human reviewers and used to improve Google's models.
 
-A key from Stanford's
-[AI API Gateway](https://uit.stanford.edu/service/ai-api-gateway){target="_blank"} is not a
-drop-in substitute. The Gateway's documented endpoints use the OpenAI and Anthropic API
-formats, not Google's, and Stanford publishes Gateway
-[setup guides](https://uit.stanford.edu/service/ai-api-gateway/userguide){target="_blank"}
-for Claude Code, Codex CLI, and Cline — but none for the Gemini CLI.
+A key from Stanford's AI API Gateway will **not** work here — the Gateway speaks the OpenAI
+API format, and the Gemini CLI only speaks Google's. See
+[Using the AI API Gateway](#using-the-ai-api-gateway) below.
 
 If you prefer a browser-based experience with your **Stanford Google account (SUNet ID)**,
 you can use
@@ -173,22 +165,37 @@ Codex is available to Stanford users through Stanford's
 [**ChatGPT Edu**](https://uit.stanford.edu/service/openai-chatgpt-edu){target="_blank"}
 service, which covers use of the CLI. When you first run `codex`, sign in with your **Stanford account**.
 
-Alternatively, you can route Codex through Stanford's
-[AI API Gateway](https://uit.stanford.edu/service/ai-api-gateway){target="_blank"}. This takes
-more than an environment variable — the Gateway is not OpenAI's endpoint, so Codex has to be
-pointed at it explicitly in `~/.codex/config.toml`, which also stops it from falling back to
-ChatGPT sign-in. Follow Stanford's
-[Codex CLI setup guide](https://uit.stanford.edu/service/ai-api-gateway/userguide/openai-codex-cli-setup){target="_blank"},
-which uses the base URL `https://aiapi-prod.stanford.edu/v1` and reads your key from:
-
-```title="Terminal Input"
-export STANFORD_AI_API_KEY=<your-api-key>
-```
-
-Note that the Gateway is a **chargeback service** — it bills monthly against a PTA, and you set
-a maximum monthly budget when you request a key.
+This is the recommended route — your usage falls under Stanford's agreement with OpenAI. To
+use Stanford's AI API Gateway instead, see
+[Using the AI API Gateway](#using-the-ai-api-gateway) below.
 
 As with the other agents, run Codex from a directory scoped to only the files the tool needs.
+
+## Using the AI API Gateway
+
+Stanford's [AI API Gateway](https://uit.stanford.edu/service/ai-api-gateway){target="_blank"}
+is a different way to reach these models: an **OpenAI-compatible API** you call from your own
+code, rather than a way to sign in to an agent.
+[Request a key](https://stanford.service-now.com/it_services?id=sc_cat_item&sys_id=fd75ec563b90265079a53434c3e45a65){target="_blank"},
+pick a model from Stanford's list, and POST to
+`https://aiapi-prod.stanford.edu/v1/chat/completions` with your key as a bearer token. It
+covers models from Anthropic, OpenAI, and Google under Stanford's terms.
+
+!!! warning "The Gateway Charges for Every Call"
+    Unlike signing in with your Stanford account, the Gateway is a **chargeback service**: you
+    pay per API call, priced by input and output tokens, and it bills monthly against a
+    **PTA**. Rates vary by model and change often — check the current
+    [AI API Gateway rates](https://uit.stanford.edu/service/ai-api-gateway/rates){target="_blank"}
+    before you start, and set a maximum monthly budget when you request your key.
+
+For the agents on this page, signing in with your Stanford account is simpler and is already
+covered by Stanford's agreements. If you do want to route an agent through the Gateway, each
+one needs its own configuration — follow Stanford's setup guides for
+[Claude Code](https://uit.stanford.edu/service/ai-api-gateway/userguide/claude-cli-setup){target="_blank"}
+and
+[Codex CLI](https://uit.stanford.edu/service/ai-api-gateway/userguide/openai-codex-cli-setup){target="_blank"}.
+The Gemini CLI cannot use the Gateway at all, since the Gateway exposes nothing in Google's
+API format.
 
 ## Your Responsibilities
 

--- a/docs/_user_guide/ai_agents.md
+++ b/docs/_user_guide/ai_agents.md
@@ -18,17 +18,17 @@ below **before** you load or run any of these tools.
 
     - **Do not** use these tools with any data covered by a signed **Data Use Agreement
       (DUA)** or **NDA**, or with licensed data whose terms restrict AI use.
-    - Before you begin, check Stanford's
-      [guidance on which AI services are approved for which data](https://uit.stanford.edu/ai/services/explore){target="_blank"}.
     - **Do not** feed data licensed by the GSB Library into an external AI tool. The library's
       [eResources Usage Policy](https://www.gsb.stanford.edu/library/research-resources/usage-policy){target="_blank"}
       has an **"AI or LLM usage"** section covering what is and is not permitted with
       licensed content.
     - Even if you are not using restricted data with an agent, storing restricted data on the
-      same system means a misconfiguration or accident could expose it.
-    - If you are unsure whether your data can be used with AI tools, **contact the GSB Library
-      and data governance team at
-      [gsb-library_research-data-coordination@stanford.edu](mailto:gsb-library_research-data-coordination@stanford.edu){target="_blank"}
+      same system means a misconfiguration or accident could expose it. Check Stanford's
+      [guidance on which AI services are approved for which data](https://uit.stanford.edu/ai/services/explore){target="_blank"}
+      before you begin.
+    - If you are unsure whether your data can be used with AI tools, **contact the
+      [GSB Data Acquisition and Governance team](https://gsbresearchhub.stanford.edu/support-units/data-acquisition-and-governance){target="_blank"}
+      at [gsb-library_research-data-coordination@stanford.edu](mailto:gsb-library_research-data-coordination@stanford.edu){target="_blank"}
       before you use them.**
 
 ## Load an Agent Module
@@ -189,8 +189,9 @@ When you use an AI agent, keep the following in mind:
 - **Licensed data and DUAs.** Data licenses and Data Use Agreements can have specific clauses
   about where data may be stored and whether AI tools can be used on it. It is **your**
   responsibility to understand the limits of your data before pointing an AI agent at it. If
-  you have any questions, contact the GSB Library and data governance team at
-  [gsb-library_research-data-coordination@stanford.edu](mailto:gsb-library_research-data-coordination@stanford.edu){target="_blank"}.
+  you have any questions, contact the
+  [GSB Data Acquisition and Governance team](https://gsbresearchhub.stanford.edu/support-units/data-acquisition-and-governance){target="_blank"}
+  at [gsb-library_research-data-coordination@stanford.edu](mailto:gsb-library_research-data-coordination@stanford.edu){target="_blank"}.
 - **Check what is approved.** Stanford's Information Security Office maintains the
   [GenAI Tool Evaluation Matrix](https://uit.stanford.edu/ai/genai-tool-matrix){target="_blank"}
   of reviewed and approved services.

--- a/docs/_user_guide/ai_agents.md
+++ b/docs/_user_guide/ai_agents.md
@@ -91,13 +91,16 @@ claude
 Claude Code is available to Stanford users through Stanford's
 [**Claude for Education**](https://uit.stanford.edu/service/claude){target="_blank"} service,
 which covers use of the CLI. When you first run `claude`, follow the prompts to sign
-in with your **Stanford account**. Alternatively, you can use an Anthropic API key from
-Stanford's [AI API Gateway](https://uit.stanford.edu/service/ai-api-gateway){target="_blank"}
-by setting an environment variable before launching:
+in with your **Stanford account**.
 
-```title="Terminal Input"
-export ANTHROPIC_API_KEY=<your-api-key>
-```
+Alternatively, you can route Claude Code through Stanford's
+[AI API Gateway](https://uit.stanford.edu/service/ai-api-gateway){target="_blank"}. A key on
+its own is not enough: Claude Code sends requests to Anthropic unless you also point it at the
+Gateway with `ANTHROPIC_BASE_URL`, and because the Gateway authenticates with a bearer token,
+the credential goes in `ANTHROPIC_AUTH_TOKEN` rather than `ANTHROPIC_API_KEY`. Follow
+Stanford's
+[Claude Code CLI setup guide](https://uit.stanford.edu/service/ai-api-gateway/userguide/claude-cli-setup){target="_blank"}
+(Stanford login required) for the current base URL and values.
 
 Claude Code works by scanning the files it has access to, starting from the directory where
 you launch it. **Be deliberate about which directory you run it in** — launch it from a
@@ -143,10 +146,10 @@ responses may be read by human reviewers and used to improve Google's models.
 
 A key from Stanford's
 [AI API Gateway](https://uit.stanford.edu/service/ai-api-gateway){target="_blank"} is not a
-drop-in substitute: the Gateway exposes an OpenAI-compatible endpoint, while the Gemini CLI
-speaks Google's own API format. Stanford publishes Gateway
+drop-in substitute. The Gateway's documented endpoints use the OpenAI and Anthropic API
+formats, not Google's, and Stanford publishes Gateway
 [setup guides](https://uit.stanford.edu/service/ai-api-gateway/userguide){target="_blank"}
-for Codex CLI, Cline, and Roo Code, but not for the Gemini CLI.
+for Claude Code, Codex CLI, and Cline — but none for the Gemini CLI.
 
 If you prefer a browser-based experience with your **Stanford Google account (SUNet ID)**,
 you can use

--- a/docs/_user_guide/ai_agents.md
+++ b/docs/_user_guide/ai_agents.md
@@ -139,10 +139,6 @@ This is a **personal** key, and on Google's
 [free tier](https://ai.google.dev/gemini-api/terms){target="_blank"} your prompts and
 responses may be read by human reviewers and used to improve Google's models.
 
-A key from Stanford's AI API Gateway will **not** work here — the Gateway speaks the OpenAI
-API format, and the Gemini CLI only speaks Google's. See
-[Using the AI API Gateway](#using-the-ai-api-gateway) below.
-
 If you prefer a browser-based experience with your **Stanford Google account (SUNet ID)**,
 you can use
 [Gemini Enterprise AI](https://uit.stanford.edu/service/gemini-enterprise-ai){target="_blank"}

--- a/docs/_user_guide/ai_agents.md
+++ b/docs/_user_guide/ai_agents.md
@@ -17,9 +17,9 @@ below **before** you load or run any of these tools.
     external providers.
 
     - **Do not** use these tools with any data covered by a signed **Data Use Agreement
-      (DUA)** or **NDA**, or with licensed data whose terms restrict AI use. Check Stanford's
-      [guidance on which AI services are approved for which data](https://uit.stanford.edu/ai/services/explore){target="_blank"}
-      before you begin.
+      (DUA)** or **NDA**, or with licensed data whose terms restrict AI use.
+    - Before you begin, check Stanford's
+      [guidance on which AI services are approved for which data](https://uit.stanford.edu/ai/services/explore){target="_blank"}.
     - **Do not** feed data licensed by the GSB Library into an external AI tool. The library's
       [eResources Usage Policy](https://www.gsb.stanford.edu/library/research-resources/usage-policy){target="_blank"}
       has an **"AI or LLM usage"** section covering what is and is not permitted with

--- a/docs/_user_guide/ai_agents.md
+++ b/docs/_user_guide/ai_agents.md
@@ -1,0 +1,170 @@
+# AI Coding Agents on the Yens
+
+Several AI coding agents are available on the Yens as modules, including
+[Claude Code](https://docs.claude.com/en/docs/claude-code/overview){target="_blank"},
+[Gemini CLI](https://google-gemini.github.io/gemini-cli/){target="_blank"}, and
+[Codex CLI](https://developers.openai.com/codex/cli/){target="_blank"}. These are agentic
+command-line tools: they read files in your working directory, run commands on your behalf,
+and send that context to an external model provider to generate responses.
+
+Because these tools transmit your code and data to third-party services, using them on a
+shared research environment carries real data-governance responsibilities. Read the warning
+below **before** you load or run any of these tools.
+
+!!! danger "Know What Data You Send to AI Tools"
+    It is **your** responsibility to know what data an AI agent can access and transmit on
+    your behalf. These tools scan the files they are pointed at and send that content to
+    external providers.
+
+    - **Do not** use these tools with any data covered by a signed **Data Use Agreement
+      (DUA)** or **NDA**, or with licensed data whose terms restrict AI use. Check Stanford's
+      [guidance on which AI services are approved for which data](https://uit.stanford.edu/ai/services/explore){target="_blank"}
+      before you begin.
+    - Even if you are not using restricted data with an agent, storing restricted data on the
+      same system means a misconfiguration or accident could expose it.
+    - **Usage of these tools is audited.**
+    - If you are unsure whether your data can be used with AI tools, **contact the GSB Library
+      and data governance team at
+      [gsb-library_research-data-coordination@stanford.edu](mailto:gsb-library_research-data-coordination@stanford.edu){target="_blank"}
+      before you use them.**
+
+## Loading the Modules
+
+The AI agents are available via the `module` command like any other software on the Yens.
+See the available tools with:
+
+```title="Terminal Input"
+module avail claude-code
+```
+
+Load an agent with the `module load` command (or the `ml` shorthand):
+
+```title="Terminal Input"
+ml claude-code
+```
+
+```title="Terminal Input"
+ml gemini
+```
+
+```title="Terminal Input"
+ml codex
+```
+
+!!! note "You Will See a Data Responsibility Reminder"
+    When you load one of these modules — and when you launch the agent — a reminder about
+    your data-governance responsibilities is displayed. This reminder does not replace your
+    responsibility to know what data may be shared with AI tools.
+
+For a refresher on how modules work, see [Modules](/_getting_started/modules/){target="_blank"}.
+
+## Claude Code
+
+[Claude Code](https://docs.claude.com/en/docs/claude-code/overview){target="_blank"} is
+Anthropic's agentic coding tool. Load the module and launch it from your project directory:
+
+```title="Terminal Input"
+ml claude-code
+claude
+```
+
+### Authenticating
+
+Claude Code is available to Stanford users through Stanford's
+[**Claude for Education**](https://uit.stanford.edu/service/claude){target="_blank"} service,
+which covers use of the CLI. When you first run `claude`, follow the prompts to sign
+in with your **Stanford account**. Alternatively, you can use an Anthropic API key from
+Stanford's [AI API Gateway](https://uit.stanford.edu/service/ai-api-gateway){target="_blank"}
+by setting an environment variable before launching:
+
+```title="Terminal Input"
+export ANTHROPIC_API_KEY=<your-api-key>
+```
+
+Claude Code works by scanning the files it has access to, starting from the directory where
+you launch it. **Be deliberate about which directory you run it in** — launch it from a
+project directory that contains only the files the tool needs, never from a directory that
+also holds restricted or licensed data. See
+[Configuration Matters](/_policies/security/#configuration-matters){target="_blank"} for
+guidance on isolating these tools.
+
+## Gemini
+
+[Gemini CLI](https://google-gemini.github.io/gemini-cli/){target="_blank"} is Google's
+agentic coding tool. Load the module and launch it:
+
+```title="Terminal Input"
+ml gemini
+gemini
+```
+
+### Authenticating
+
+Unlike Claude Code and Codex, the Gemini CLI is **not** covered by Stanford's
+[Gemini Enterprise AI](https://uit.stanford.edu/service/gemini-enterprise-ai){target="_blank"}
+service. To use it on the Yens, you need an API key from Stanford's
+[AI API Gateway](https://uit.stanford.edu/service/ai-api-gateway){target="_blank"} —
+[request a key](https://stanford.service-now.com/it_services?id=sc_cat_item&sys_id=fd75ec563b90265079a53434c3e45a65){target="_blank"}
+tied to your Stanford account, and set it before launching:
+
+```title="Terminal Input"
+export GEMINI_API_KEY=<your-api-key>
+```
+
+If you prefer a browser-based experience with your **Stanford Google account (SUNet ID)**,
+you can use
+[Gemini Enterprise AI](https://uit.stanford.edu/service/gemini-enterprise-ai){target="_blank"}
+or the [Stanford AI Playground](https://uit.stanford.edu/aiplayground){target="_blank"}
+directly. See [University IT AI](https://uit.stanford.edu/ai){target="_blank"} for the full
+list of Stanford's AI services.
+
+## Codex
+
+[Codex CLI](https://developers.openai.com/codex/cli/){target="_blank"} is OpenAI's agentic
+coding tool. Load the module and launch it:
+
+```title="Terminal Input"
+ml codex
+codex
+```
+
+### Authenticating
+
+Codex is available to Stanford users through Stanford's
+[**ChatGPT Edu**](https://uit.stanford.edu/service/openai-chatgpt-edu){target="_blank"}
+service, which covers use of the CLI. When you first run `codex`, sign in with your **Stanford account**.
+Alternatively, you can use an OpenAI API key from Stanford's
+[AI API Gateway](https://uit.stanford.edu/service/ai-api-gateway){target="_blank"} by setting
+an environment variable before launching:
+
+```title="Terminal Input"
+export OPENAI_API_KEY=<your-api-key>
+```
+
+As with the other agents, run Codex from a directory scoped to only the files the tool needs.
+
+## Your Responsibilities
+
+When you use an AI agent, keep the following in mind:
+
+- **Licensed data and DUAs.** Data licenses and Data Use Agreements can have specific clauses
+  about where data may be stored and whether AI tools can be used on it. It is **your**
+  responsibility to understand the limits of your data before pointing an AI agent at it. If
+  you have any questions, contact the GSB Library and data governance team at
+  [gsb-library_research-data-coordination@stanford.edu](mailto:gsb-library_research-data-coordination@stanford.edu){target="_blank"}.
+- **Check what is approved.** Stanford's Information Security Office maintains the
+  [GenAI Tool Evaluation Matrix](https://uit.stanford.edu/ai/genai-tool-matrix){target="_blank"}
+  of reviewed and approved services.
+- **Authenticate with your Stanford account.** Stanford has
+  [enterprise agreements](https://uit.stanford.edu/news/new-ai-tools-stanford-arrive-june-30){target="_blank"}
+  with vendors — including Anthropic's
+  [Claude for Education](https://uit.stanford.edu/service/claude){target="_blank"} and OpenAI's
+  [ChatGPT Edu](https://uit.stanford.edu/service/openai-chatgpt-edu){target="_blank"} — that
+  cover use of these agents under terms governing data use, retention, and model training (your
+  conversations are not used to train the vendors' models). Sign in with your Stanford account
+  so your usage falls under these agreements, rather than a personal account.
+
+## See Also
+
+- [Security](/_policies/security/){target="_blank"} — data classification and AI tooling policy.
+- [Modules](/_getting_started/modules/){target="_blank"} — how software modules work on the Yens.

--- a/docs/_user_guide/ai_agents.md
+++ b/docs/_user_guide/ai_agents.md
@@ -20,51 +20,69 @@ below **before** you load or run any of these tools.
       (DUA)** or **NDA**, or with licensed data whose terms restrict AI use. Check Stanford's
       [guidance on which AI services are approved for which data](https://uit.stanford.edu/ai/services/explore){target="_blank"}
       before you begin.
+    - **Do not** feed data licensed by the GSB Library into an external AI tool. The library's
+      [eResources Usage Policy](https://www.gsb.stanford.edu/library/research-resources/usage-policy){target="_blank"}
+      has an **"AI or LLM usage"** section covering what is and is not permitted with
+      licensed content.
     - Even if you are not using restricted data with an agent, storing restricted data on the
       same system means a misconfiguration or accident could expose it.
-    - **Usage of these tools is audited.**
     - If you are unsure whether your data can be used with AI tools, **contact the GSB Library
       and data governance team at
       [gsb-library_research-data-coordination@stanford.edu](mailto:gsb-library_research-data-coordination@stanford.edu){target="_blank"}
       before you use them.**
 
-## Loading the Modules
+## Load an Agent Module
 
-The AI agents are available via the `module` command like any other software on the Yens.
-See the available tools with:
-
-```title="Terminal Input"
-module avail claude-code
-```
-
-Load an agent with the `module load` command (or the `ml` shorthand):
+On the Yens, the AI agents are available via the `module` command. See all currently
+installed versions with:
 
 ```title="Terminal Input"
-ml claude-code
+module avail claude-code codex gemini
 ```
+
+You will see the available agent versions listed:
+
+```{.yaml .no-copy title="Terminal Output"}
+
+------------------------------------------------------------------------ Global Aliases -------------------------------------------------------------------------
+
+
+-------------------------------------------------------------------- /software/modules/Core ---------------------------------------------------------------------
+   claude-code/2.1.220    codex/0.146.0    gemini/0.53.1
+```
+
+To use an agent, load its module:
+
+=== "Claude Code"
+    ```title="Terminal Input"
+    ml claude-code
+    ```
+
+=== "Gemini CLI"
+    ```title="Terminal Input"
+    ml gemini
+    ```
+
+=== "Codex"
+    ```title="Terminal Input"
+    ml codex
+    ```
+
+This loads the default version. To pin a specific one:
 
 ```title="Terminal Input"
-ml gemini
+ml claude-code/2.1.220
 ```
-
-```title="Terminal Input"
-ml codex
-```
-
-!!! note "You Will See a Data Responsibility Reminder"
-    When you load one of these modules — and when you launch the agent — a reminder about
-    your data-governance responsibilities is displayed. This reminder does not replace your
-    responsibility to know what data may be shared with AI tools.
 
 For a refresher on how modules work, see [Modules](/_getting_started/modules/){target="_blank"}.
 
 ## Claude Code
 
 [Claude Code](https://docs.claude.com/en/docs/claude-code/overview){target="_blank"} is
-Anthropic's agentic coding tool. Load the module and launch it from your project directory:
+Anthropic's agentic coding tool. With the module loaded, launch it from your project
+directory:
 
 ```title="Terminal Input"
-ml claude-code
 claude
 ```
 
@@ -91,25 +109,44 @@ guidance on isolating these tools.
 ## Gemini
 
 [Gemini CLI](https://google-gemini.github.io/gemini-cli/){target="_blank"} is Google's
-agentic coding tool. Load the module and launch it:
+agentic coding tool. With the module loaded, launch it:
 
 ```title="Terminal Input"
-ml gemini
 gemini
 ```
 
 ### Authenticating
 
-Unlike Claude Code and Codex, the Gemini CLI is **not** covered by Stanford's
-[Gemini Enterprise AI](https://uit.stanford.edu/service/gemini-enterprise-ai){target="_blank"}
-service. To use it on the Yens, you need an API key from Stanford's
-[AI API Gateway](https://uit.stanford.edu/service/ai-api-gateway){target="_blank"} —
-[request a key](https://stanford.service-now.com/it_services?id=sc_cat_item&sys_id=fd75ec563b90265079a53434c3e45a65){target="_blank"}
-tied to your Stanford account, and set it before launching:
+!!! warning "Gemini CLI Is Not Covered by Stanford's Enterprise Agreement"
+    Unlike Claude Code and Codex, the Gemini CLI falls **outside** Stanford's
+    [Gemini Enterprise AI](https://uit.stanford.edu/service/gemini-enterprise-ai){target="_blank"}
+    service. Stanford's agreements with Anthropic and OpenAI govern how your data is used,
+    retained, and whether it trains the vendors' models — **none of that applies here**.
+    Anything you send through the Gemini CLI goes to Google outside those protections, so
+    treat it as an unapproved external service and keep non-public research data out of it.
+
+The first time you run `gemini`, it asks how you want to authenticate — **Sign in with
+Google**, **Use Gemini API Key**, or **Vertex AI**. None of these route through a Stanford
+agreement.
+
+The simplest option is a [Gemini API key](https://aistudio.google.com/apikey){target="_blank"}
+from Google AI Studio, which has a free tier. Set it before launching and the CLI will detect
+it automatically:
 
 ```title="Terminal Input"
 export GEMINI_API_KEY=<your-api-key>
 ```
+
+This is a **personal** key, and on Google's
+[free tier](https://ai.google.dev/gemini-api/terms){target="_blank"} your prompts and
+responses may be read by human reviewers and used to improve Google's models.
+
+A key from Stanford's
+[AI API Gateway](https://uit.stanford.edu/service/ai-api-gateway){target="_blank"} is not a
+drop-in substitute: the Gateway exposes an OpenAI-compatible endpoint, while the Gemini CLI
+speaks Google's own API format. Stanford publishes Gateway
+[setup guides](https://uit.stanford.edu/service/ai-api-gateway/userguide){target="_blank"}
+for Codex CLI, Cline, and Roo Code, but not for the Gemini CLI.
 
 If you prefer a browser-based experience with your **Stanford Google account (SUNet ID)**,
 you can use
@@ -121,10 +158,9 @@ list of Stanford's AI services.
 ## Codex
 
 [Codex CLI](https://developers.openai.com/codex/cli/){target="_blank"} is OpenAI's agentic
-coding tool. Load the module and launch it:
+coding tool. With the module loaded, launch it:
 
 ```title="Terminal Input"
-ml codex
 codex
 ```
 
@@ -133,13 +169,21 @@ codex
 Codex is available to Stanford users through Stanford's
 [**ChatGPT Edu**](https://uit.stanford.edu/service/openai-chatgpt-edu){target="_blank"}
 service, which covers use of the CLI. When you first run `codex`, sign in with your **Stanford account**.
-Alternatively, you can use an OpenAI API key from Stanford's
-[AI API Gateway](https://uit.stanford.edu/service/ai-api-gateway){target="_blank"} by setting
-an environment variable before launching:
+
+Alternatively, you can route Codex through Stanford's
+[AI API Gateway](https://uit.stanford.edu/service/ai-api-gateway){target="_blank"}. This takes
+more than an environment variable — the Gateway is not OpenAI's endpoint, so Codex has to be
+pointed at it explicitly in `~/.codex/config.toml`, which also stops it from falling back to
+ChatGPT sign-in. Follow Stanford's
+[Codex CLI setup guide](https://uit.stanford.edu/service/ai-api-gateway/userguide/openai-codex-cli-setup){target="_blank"},
+which uses the base URL `https://aiapi-prod.stanford.edu/v1` and reads your key from:
 
 ```title="Terminal Input"
-export OPENAI_API_KEY=<your-api-key>
+export STANFORD_AI_API_KEY=<your-api-key>
 ```
+
+Note that the Gateway is a **chargeback service** — it bills monthly against a PTA, and you set
+a maximum monthly budget when you request a key.
 
 As with the other agents, run Codex from a directory scoped to only the files the tool needs.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
           - Running R Interactively: _user_guide/r.md
           - RStudio: _user_guide/rstudio.md
           - Best Practices in R: _user_guide/parallel_processing_r.md
+      - AI Coding Agents: _user_guide/ai_agents.md
       - Matlab: _user_guide/matlab_interactive.md
       - Julia: _user_guide/julia.md
       - SAS: _user_guide/sas.md          


### PR DESCRIPTION
## Summary

Adds a new **AI Tools → AI Coding Agents** documentation page and reinforces data-governance warnings now that `claude-code`, `codex`, and `gemini` are installed as modules on the Yens.

## Changes

**New page `docs/_user_guide/ai_agents.md`** — how to load the agent modules, with a per-tool **Authenticating** section for each:

| Tool | How to authenticate | Covered by a Stanford agreement? |
| --- | --- | --- |
| Claude Code | Sign in with your Stanford account | Yes — [Claude for Education](https://uit.stanford.edu/service/claude) |
| Codex | Sign in with your Stanford account | Yes — [ChatGPT Edu](https://uit.stanford.edu/service/openai-chatgpt-edu) |
| Gemini CLI | Personal [Google AI Studio](https://aistudio.google.com/apikey) key via `GEMINI_API_KEY` | **No** |

The Gemini CLI is the one tool outside a Stanford agreement — [Gemini Enterprise AI](https://uit.stanford.edu/service/gemini-enterprise-ai) is browser-only and does not cover it. The page carries a warning admonition saying so plainly: nothing governs how Google uses that data, and on the free tier prompts may be read by human reviewers and used to improve Google's models. It is ordered last, after the two covered tools.

The page also has a **"Know What Data You Send to AI Tools"** danger admonition (DUA/NDA, GSB Library licensed content, restricted data on shared systems, who to contact) and a **Your Responsibilities** section. A single **Using the AI API Gateway** section explains that the Gateway is an OpenAI-compatible API you call from your own code — not a way to sign an agent in — and points at [Stanford's LLM API Tools](https://rcpedia.stanford.edu/blog/2026/03/06/stanfords-llm-api-tools/) for how to request a key and start making calls.

**`mkdocs.yml`** — new **AI Tools** subsection in the User Guide nav.

**`docs/_getting_started/modules.md`** — added Claude Code, Codex, Gemini CLI, and GitHub CLI to the software list, plus a data-responsibility danger admonition cross-linking the new page.

**`docs/_policies/security.md`** — cross-link to the new page; contact updated to the [GSB Data Acquisition and Governance team](https://gsbresearchhub.stanford.edu/support-units/data-acquisition-and-governance) with the email alongside; removed the outdated "Other Tooling can Help" and "Data Risk" subsections, whose content is already carried by the Data Classification table above and by the new page.

## Verification

`mkdocs build` is clean with no new warnings. All pages render locally, the nav entry works, and internal links resolve — including `/_policies/security/#configuration-matters`, whose anchor survives the restructure here.

Authentication instructions were checked against Stanford's and the vendors' own documentation rather than written from assumption. Two corrections came out of that: Claude Code and Codex cannot reach the AI API Gateway with a bare `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`, and the Gemini CLI cannot use a Gateway key at all. Rather than restate setup steps that may drift, the page links Stanford's own per-tool setup guides.

## Review

All ten review threads from @alexstorer are applied and resolved — team name, bullet structure, and tool order in 586f376f; the Gemini reorder in c43d204f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
